### PR TITLE
automatic SQL migration

### DIFF
--- a/automatic.go
+++ b/automatic.go
@@ -29,13 +29,9 @@ func Automatic(db *sql.DB, dir string) error {
 			return errors.Wrapf(err, "Up: migrating from %d -> %d", currentVersion, topVersion)
 		}
 	} else if currentVersion > topVersion {
-		// dump the SQL files stored in the DB
+		// down using the SQL files stored in the DB
 		if err = downFromDb(db, topVersion+1); err != nil {
 			return errors.Wrapf(err, "downFromDb: downloading migrations from %d->%d", topVersion+1, currentVersion)
-		}
-
-		if err = DownTo(db, dir, topVersion); err != nil {
-			return errors.Wrapf(err, "DownTo: down versioning the DB to %d", topVersion)
 		}
 	} else {
 		fmt.Printf("goose: no migrations to run. current version: %d, top most migration: %d\n", currentVersion, topVersion)

--- a/automatic.go
+++ b/automatic.go
@@ -1,0 +1,76 @@
+package goose
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func Automatic(db *sql.DB, dir string) error {
+	currentVersion, err := GetDBVersion(db)
+	if err != nil {
+		return errors.Wrapf(err, "GetDBVersion: getting the applied version in the DB")
+	}
+
+	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
+	if err != nil {
+		return errors.Wrapf(err, "CollectMigrations: retrieving the migration files in the directory")
+	}
+
+	migrationsLen := len(migrations)
+	topVersion := int64(0)
+	if migrationsLen != 0 {
+		topVersion = migrations[migrationsLen - 1].Version
+	}
+	if currentVersion < topVersion {
+		if err := Up(db, dir); err != nil {
+			return errors.Wrapf(err, "Up: migrating from %d -> %d", currentVersion, topVersion)
+		}
+	} else if currentVersion > topVersion {
+		// dump the SQL files stored in the DB
+		if err = downFromDb(db, topVersion+1); err != nil {
+			return errors.Wrapf(err, "downFromDb: downloading migrations from %d->%d", topVersion+1, currentVersion)
+		}
+
+		if err = DownTo(db, dir, topVersion); err != nil {
+			return errors.Wrapf(err, "DownTo: down versioning the DB to %d", topVersion)
+		}
+	} else {
+		fmt.Printf("goose: no migrations to run. current version: %d, top most migration: %d\n", currentVersion, topVersion)
+	}
+
+	return nil
+}
+
+func downFromDb(db *sql.DB, fromVersion int64) error{
+	rows, err := GetDialect().dbVersionQuery(db)
+	if err != nil {
+		return errors.Wrapf(err, "dbVersionQuery: getting all applied DB versions")
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var row MigrationRecord
+		if err = rows.Scan(&row.VersionID, &row.IsApplied, &row.DownData); err != nil {
+			return errors.Wrapf(err, "Scan: scanning the migration record")
+		}
+		if row.VersionID < fromVersion || row.VersionID == 0 {
+			break
+		}
+
+		log.Println("Performing goose down: ", row.DownData)
+		r := strings.NewReader(row.DownData)
+		statements, useTx, err := parseSQLMigration(r, false)
+		if err != nil {
+			return errors.Wrapf(err, "ERROR %v: failed to parse SQL migration file from DB")
+		}
+
+		if err := runSQLMigration(db, statements, useTx, statements, row.VersionID, false); err != nil {
+			return errors.Wrapf(err, "ERROR %v: failed to run down SQL migration from DB")
+		}
+	}
+
+	return nil
+}

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/pressly/goose"
+	"github.com/prasoontelang/goose"
 )
 
 var (
@@ -102,6 +102,7 @@ Options:
 
 	usageCommands = `
 Commands:
+    automatic            (for SQL only) Compare DB version and SQL files to decide Migration/Rollback of the DB
     up                   Migrate the DB to the most recent version available
     up-to VERSION        Migrate the DB to a specific VERSION
     down                 Roll back the version by 1

--- a/examples/automatic/automatic-down/00001_create_users_table.sql
+++ b/examples/automatic/automatic-down/00001_create_users_table.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+CREATE TABLE users (
+                       id int NOT NULL PRIMARY KEY,
+                       username text,
+                       name text,
+                       surname text
+);
+
+-- +goose Down
+DROP TABLE users;

--- a/examples/automatic/automatic-up/00001_create_users_table.sql
+++ b/examples/automatic/automatic-up/00001_create_users_table.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+CREATE TABLE users (
+                       id int NOT NULL PRIMARY KEY,
+                       username text,
+                       name text,
+                       surname text
+);
+
+-- +goose Down
+DROP TABLE users;

--- a/examples/automatic/automatic-up/00002_insert_users.sql
+++ b/examples/automatic/automatic-up/00002_insert_users.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+INSERT INTO users VALUES
+(0, 'root', '', ''),
+(1, 'vojtechvitek', 'Vojtech', 'Vitek');
+
+-- +goose Down
+DELETE FROM users;

--- a/examples/automatic/run_script.sh
+++ b/examples/automatic/run_script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# shell script for Mac-only
+
+# set the PG_URL to the postgres instance for testing
+PG_URL="postgres://localhost:5432?sslmode=disable"
+GEESE="../../bin/goose-darwin64"
+
+display() {
+  echo "*** ${1} ***"
+}
+
+# ./automatic-up contains the SQL version higher than the DB version
+display "Automatic operation chooses Goose Up"
+${GEESE} --dir ./automatic-up postgres "${PG_URL}" automatic
+
+# display the contents from the users table
+display "Results from the Goose Up - entries in the users table"
+psql --command 'SELECT * FROM users;'  "${PG_URL}"
+
+# ./automatic-down contains the SQL version lower than the DB version
+display "Automatic operation chooses Goose down"
+${GEESE} --dir ./automatic-down postgres "${PG_URL}" automatic
+
+# there are no entries in the users table
+display "Results from the Goose Down - empty users table"
+psql --command 'SELECT * FROM users;' "${PG_URL}"

--- a/goose.go
+++ b/goose.go
@@ -24,6 +24,10 @@ func SetVerbose(v bool) {
 
 // Run runs a goose command.
 func Run(command string, db *sql.DB, dir string, args ...string) error {
+	// (prasoontelang) this add Migration column is used only to upgrade goose DB itself
+	if err := UpdateGooseTable(db); err != nil {
+		log.Printf("Error: %+v. UpdateGooseTable: updating goose's metadata.\n", err)
+	}
 	switch command {
 	case "up":
 		if err := Up(db, dir); err != nil {
@@ -91,6 +95,10 @@ func Run(command string, db *sql.DB, dir string, args ...string) error {
 		}
 	case "version":
 		if err := Version(db, dir); err != nil {
+			return err
+		}
+	case "automatic":
+		if err := Automatic(db, dir); err != nil {
 			return err
 		}
 	default:

--- a/reset.go
+++ b/reset.go
@@ -45,7 +45,7 @@ func dbMigrationsStatus(db *sql.DB) (map[int64]bool, error) {
 
 	for rows.Next() {
 		var row MigrationRecord
-		if err = rows.Scan(&row.VersionID, &row.IsApplied); err != nil {
+		if err = rows.Scan(&row.VersionID, &row.IsApplied, &row.DownData); err != nil {
 			return nil, errors.Wrap(err, "failed to scan row")
 		}
 


### PR DESCRIPTION
Introducing 'automatic' version which uses the DB version and the local
SQL file version to decide between update or rollback dynamically.

The local version in the filesystem is the desired state and the schema
in the DB is the current state. Goose with automatic will attempt to
match the DB version to the desired state in local.

To achieve this, it stores the SQL files persistently into the DB.
Hence if the SQL files are removed, it uses the same SQL entries to
perform goose down.